### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "type": "git",
     "url": "https://github.com/cloudfoundry-community/etherpad-lite-cf.git"
   },
-  "version": "1.5.7-cf"
+  "version": "1.5.7-cf",
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
**What**
The [NPM Docs](https://docs.npmjs.com/files/package.json) say :
"You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it."

*Added 'Apache-2.0'  SPDX license identifier field to match the LICENSE file from this repo.

Nothing major... it just gets rid of an NPM warning.

**How to test this PR**

No changes to code, but this should get rid of a warning from NPM.
